### PR TITLE
Typos

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -34,7 +34,7 @@ class GamesController < ApplicationController
     
      
     @game.update_attributes(game_params)
-    @game.black_player_id << current_user.id
+    @game.white_player_id << current_user.id
       redirect_to game_path(@game)
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -21,7 +21,7 @@ class Game < ApplicationRecord
    Piece.create!(game_id: self.id, type: "Bishop", x_position: 5, y_position: 7, user_id: self.white_player_id, color: "white")
     #Black Pieces
     (0..7).each do |i|
-      Piece.create!(game_id: self.id, type: "Pawn", x_position: i, y_position: 1, user_id: self.white_player_id, color: "black")
+      Piece.create!(game_id: self.id, type: "Pawn", x_position: i, y_position: 1, user_id: self.black_player_id, color: "black")
     end
    Piece.create!(game_id: self.id, type: "King", x_position: 3, y_position: 0, user_id: self.black_player_id, color: "black")
    Piece.create!(game_id: self.id, type: "Queen", x_position: 4, y_position: 0, user_id: self.black_player_id, color: "black")

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -9,15 +9,15 @@ class Pawn < Piece
     x_distance = x_distance(new_x_position)
     y_distance = y_distance(new_y_position)
 #---Opening Move-----#
-    if y_position == 2 && white
+    if y_position == 2 && color
       x_distance == 0 && (new_y_position == 3 || new_y_position == 4)
-    elsif y_position == 7 && black
+    elsif y_position == 7 && color 
       x_distance == 0 && (new_y_position == 6 || new_y_position == 5)
 #---Otherwise---#
     else
-      if white
+      if color 
         (x_distance == 0) && (new_y_position == (y_position + 1))
-      elsif black
+      elsif color 
         (x_distance == 0) && (new_y_position == (y_position - 1))
       end
     end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -9,15 +9,15 @@ class Pawn < Piece
     x_distance = x_distance(new_x_position)
     y_distance = y_distance(new_y_position)
 #---Opening Move-----#
-    if y_position == 2 && white!
+    if y_position == 2 && white
       x_distance == 0 && (new_y_position == 3 || new_y_position == 4)
-    elsif y_position == 7 && black!
+    elsif y_position == 7 && black
       x_distance == 0 && (new_y_position == 6 || new_y_position == 5)
 #---Otherwise---#
     else
-      if white!
+      if white
         (x_distance == 0) && (new_y_position == (y_position + 1))
-      elsif black!
+      elsif black
         (x_distance == 0) && (new_y_position == (y_position - 1))
       end
     end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,5 +1,5 @@
 class Piece < ApplicationRecord
-  enum color: %i[black white]
+  #enum color: %i[black white]
   belongs_to :game
   validates :type, inclusion: { in: %w(Pawn Rook Bishop Knight King Queen) }
 
@@ -81,7 +81,7 @@ class Piece < ApplicationRecord
   end
 
   def image
-    "#{color}#{type}.png"
+    "#{color}#{type.downcase}.png"
   end
 
   def up?(new_y_position)

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -28,6 +28,7 @@
                       <br />
                       <span class="column turn"><%= f.submit "Join as white player", class: "btn btn-secondary" %></span>
                     <% end %>
+                  <% end %>
           
                   <% else %>
                     <%= simple_form_for game, url: join_game_path(game) do |f| %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -16,7 +16,8 @@
             <td class="square" data-x="<%= x %>" data-y="<%= y %>">
               <% piece = @game.piece_for_position(x, y) %>
                 <% if piece %>
-                  <%= image_tag(piece.image) %>
+                <%= image_tag(piece.image) %>
+                
                 <% end %>
             </td>
           <% end %>
@@ -30,14 +31,14 @@
 <h5>These are the game details</h5>
 <p><%= @game.inspect %></p>
 <h5>These are the players</h5>
-  <p>White player: <%= @game.white_player.email %></p>
-  <p>Black player: <%= @game.black_player.email %></p>
+  <p>White player: <%= @game.white_player&.email %></p>
+  <p>Black player: <%= @game.black_player&.email %></p>
 
   <%= simple_form_for @game, url: forfeit_game_path(@game) do |f| %>
     <% if current_user.id == @game.white_player_id %>
-      <%= f.input :winner_user_id, as: :hidden, :input_html => { :value => @game.black_player.id } %>
+      <%= f.input :winner_user_id, as: :hidden, :input_html => { :value => @game.black_player&.id } %>
     <% else %>
-      <%= f.input :winner_user_id, as: :hidden, :input_html => { :value => @game.white_player.id } %>
+      <%= f.input :winner_user_id, as: :hidden, :input_html => { :value => @game.white_player&.id } %>
     <% end %>
     <%= f.submit "I FORFEIT!", class: "btn btn-primary col-4" %>
   <% end %>


### PR DESCRIPTION
I started this branch to fix the typos I had made but we ended up using it to fix the bug causing the pieces not to show on the board. So the color attributes were not set because the enum color was set to the same causing it to override the attributes so we commented out the enum color: %i[black white].So we did a query to find the pieces for game 3 that had a user id and updated all those pieces, then we did the opposite(user.id null)and set all those pieces to the color black. That made the pieces show but we were getting a row of white pawns on the black side so we looked through the actual pawn pieces and found a typo -Piece.create!(game_id: self.id, type: "Pawn", x_position: i, y_position: 1, user_id: self.white_player_id, color: "black") we changed this to black and now have the pieces on the board !!!!! 